### PR TITLE
Gtk bridge

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,8 @@ if test x"${i_do_have_x}" = xyes || test x"${fontforge_can_use_gdk}" = xyes; the
     i_do_have_gui=yes
 fi
 
+FONTFORGE_ARG_ENABLE_GTK_BRIDGE
+
 AC_SUBST([HOST],["$host"])
 AC_SUBST([MACAPP])
 
@@ -666,6 +668,7 @@ my_cflags="${my_cflags} ${GLIB_CFLAGS}"
 my_cflags="${my_cflags} ${CAIRO_CFLAGS}"
 my_cflags="${my_cflags} ${PANGO_CFLAGS}"
 my_cflags="${my_cflags} ${GDK_CFLAGS}"
+my_cflags="${my_cflags} ${GTK_CFLAGS}"
 my_cflags="${my_cflags} ${WOFF2_CFLAGS}"
 my_cflags="${my_cflags} ${PANGOCAIRO_CFLAGS}"
 my_cflags="${my_cflags} ${FREETYPE_CFLAGS}"
@@ -703,6 +706,10 @@ if test x"${fontforge_can_use_gdk}" = xyes; then
     my_libs="${my_libs} ${GDK_LIBS}"
 else
     test x"${i_do_have_x}" = xyes && my_libs="${my_libs} ${X_PRE_LIBS} ${X_LIBS} ${X_EXTRA_LIBS}"
+fi
+
+if test x"${fontforge_can_use_gtk_bridge}" = xyes; then
+    my_libs="${my_libs} ${GTK_LIBS}"
 fi
 
 test x"${i_do_have_libreadline}" = xyes && my_libs="${my_libs} ${LIBREADLINE_LIBS}"

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -128,6 +128,10 @@ extern int old_sfnt_flags;
 #include "collabclient.h"
 #include <ffglib.h>
 
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+#include "gdraw/gtkbridge.h"
+#endif
+
 extern int prefRevisionsToRetain;
 
 #include "gutils/unicodelibinfo.h"
@@ -17381,6 +17385,28 @@ return (NULL);
 Py_RETURN( self );
 }
 
+static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *UNUSED(args)) {
+	PyObject *w;
+
+#ifndef FONTFORGE_CAN_USE_GTK_BRIDGE
+	PyErr_Format(PyExc_EnvironmentError, "FontForge not compiled with GTK extension");
+	return( NULL );
+#else
+	if ( no_windowing_ui ) {
+		PyErr_Format(PyExc_EnvironmentError, "No user interface");
+		return( NULL );
+	}
+
+	gtkb_addWindow();
+
+/*	if ( !PyArg_ParseTuple(args,"O",&w) ) 
+		return (NULL);
+	printf("%s", Py_TYPE(w)->tp_name);
+*/
+	Py_RETURN( self );
+#endif
+}
+
 static PyObject *PyFFFont_Intersect(PyFF_Font *self, PyObject *UNUSED(args)) {
     if ( CheckIfFontClosed(self) )
 return (NULL);
@@ -17509,6 +17535,7 @@ PyMethodDef PyFF_Font_methods[] = {
 /* Selection based */
     { "clear", (PyCFunction) PyFFFont_clear, METH_NOARGS, "Clears all selected glyphs" },
     { "cut", (PyCFunction) PyFFFont_cut, METH_NOARGS, "Cuts all selected glyphs" },
+    { "addWindow", (PyCFunction) PyFFFont_addWindow, METH_VARARGS, "Adds gtk window to event loop" },
     { "copy", (PyCFunction) PyFFFont_copy, METH_NOARGS, "Copies all selected glyphs" },
     { "copyReference", (PyCFunction) PyFFFont_copyReference, METH_NOARGS, "Copies all selected glyphs as references" },
     { "paste", (PyCFunction) PyFFFont_paste, METH_NOARGS, "Pastes the clipboard into the selected glyphs (clearing them first)" },

--- a/fontforge/python.c
+++ b/fontforge/python.c
@@ -128,10 +128,6 @@ extern int old_sfnt_flags;
 #include "collabclient.h"
 #include <ffglib.h>
 
-#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
-#include "gdraw/gtkbridge.h"
-#endif
-
 extern int prefRevisionsToRetain;
 
 #include "gutils/unicodelibinfo.h"
@@ -17385,28 +17381,6 @@ return (NULL);
 Py_RETURN( self );
 }
 
-static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *UNUSED(args)) {
-	PyObject *w;
-
-#ifndef FONTFORGE_CAN_USE_GTK_BRIDGE
-	PyErr_Format(PyExc_EnvironmentError, "FontForge not compiled with GTK extension");
-	return( NULL );
-#else
-	if ( no_windowing_ui ) {
-		PyErr_Format(PyExc_EnvironmentError, "No user interface");
-		return( NULL );
-	}
-
-	gtkb_addWindow();
-
-/*	if ( !PyArg_ParseTuple(args,"O",&w) ) 
-		return (NULL);
-	printf("%s", Py_TYPE(w)->tp_name);
-*/
-	Py_RETURN( self );
-#endif
-}
-
 static PyObject *PyFFFont_Intersect(PyFF_Font *self, PyObject *UNUSED(args)) {
     if ( CheckIfFontClosed(self) )
 return (NULL);
@@ -17535,7 +17509,6 @@ PyMethodDef PyFF_Font_methods[] = {
 /* Selection based */
     { "clear", (PyCFunction) PyFFFont_clear, METH_NOARGS, "Clears all selected glyphs" },
     { "cut", (PyCFunction) PyFFFont_cut, METH_NOARGS, "Cuts all selected glyphs" },
-    { "addWindow", (PyCFunction) PyFFFont_addWindow, METH_VARARGS, "Adds gtk window to event loop" },
     { "copy", (PyCFunction) PyFFFont_copy, METH_NOARGS, "Copies all selected glyphs" },
     { "copyReference", (PyCFunction) PyFFFont_copyReference, METH_NOARGS, "Copies all selected glyphs as references" },
     { "paste", (PyCFunction) PyFFFont_paste, METH_NOARGS, "Pastes the clipboard into the selected glyphs (clearing them first)" },

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -53,6 +53,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include "ffpython.h"
+#include "gdraw/gtkbridge.h"
 
 #include "gnetwork.h"
 #ifdef BUILD_COLLAB
@@ -567,7 +568,7 @@ static PyObject *PyFFFont_CollabSessionSetUpdatedCallback(PyFF_Font *self, PyObj
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef FONTFORGE_CAN_USE_GTK
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
 
 #define GMenuItem GMenuItem_Glib
 #define GTimer GTimer_GTK
@@ -596,12 +597,12 @@ static PyObject *PyFFFont_addGtkWindowToMainEventLoop(PyFF_Font *self, PyObject 
     if ( !PyArg_ParseTuple( args, "i", &v ))
         return( NULL );
 
-    gpointer gdkwindow = gdk_xid_table_lookup( v );
+    gpointer gdkwindow = gdk_x11_window_lookup_for_display(gdk_display_get_default(), v );
 
     if( gdkwindow )
     {
         Display* d = GDK_WINDOW_XDISPLAY(gdkwindow);
-        int fd = XConnectionNumber(d);
+        int fd = ConnectionNumber(d);
         if( fd )
         {
             gpointer udata = 0;
@@ -624,12 +625,12 @@ static PyObject *PyFFFont_getGtkWindowMainEventLoopFD(PyFF_Font *self, PyObject 
     if ( !PyArg_ParseTuple( args, "i", &v ))
         return( NULL );
 
-    gpointer gdkwindow = gdk_xid_table_lookup( v );
+    gpointer gdkwindow = gdk_x11_window_lookup_for_display(gdk_display_get_default(), v );
 
     if( gdkwindow )
     {
         Display* d = GDK_WINDOW_XDISPLAY(gdkwindow);
-        int fd = XConnectionNumber(d);
+        int fd = ConnectionNumber(d);
         if( fd )
         {
 	    return( Py_BuildValue("i", fd ));
@@ -651,12 +652,12 @@ static PyObject *PyFFFont_removeGtkWindowToMainEventLoop(PyFF_Font *self, PyObje
     if ( !PyArg_ParseTuple( args, "i", &v ))
         return( NULL );
 
-    gpointer gdkwindow = gdk_xid_table_lookup( v );
+    gpointer gdkwindow = gdk_x11_window_lookup_for_display(gdk_display_get_default(), v );
 
     if( gdkwindow )
     {
         Display* d = GDK_WINDOW_XDISPLAY(gdkwindow);
-        int fd = XConnectionNumber(d);
+        int fd = ConnectionNumber(d);
         if( fd )
         {
             gpointer udata = 0;
@@ -689,6 +690,30 @@ static PyObject *PyFFFont_removeGtkWindowToMainEventLoopByFD(PyFF_Font *self, Py
     return result;
 }
 
+static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *UNUSED(args)) {
+	PyObject *w;
+
+	/*PyErr_Format(PyExc_EnvironmentError, "FontForge not compiled with GTK extension");
+	return( NULL );*/
+
+	/*if ( no_windowing_ui ) {
+		PyErr_Format(PyExc_EnvironmentError, "No user interface");
+		return( NULL );
+	}*/
+
+	gtkb_addWindow();
+	/*gboolean may_block = false;
+	GMainContext *con = g_main_context_default();
+	while (g_main_context_pending(con))
+		g_main_context_iteration( con, may_block ); */
+
+/*	if ( !PyArg_ParseTuple(args,"O",&w) ) 
+		return (NULL);
+	printf("%s", Py_TYPE(w)->tp_name);
+*/
+	Py_RETURN( self );
+}
+
 #else
 
 #define EMPTY_METHOD				\
@@ -707,6 +732,8 @@ static PyObject *PyFFFont_getGtkWindowMainEventLoopFD(PyFF_Font *self, PyObject 
 static PyObject *PyFFFont_removeGtkWindowToMainEventLoop(PyFF_Font *self, PyObject *args)
 { EMPTY_METHOD; }
 static PyObject *PyFFFont_removeGtkWindowToMainEventLoopByFD(PyFF_Font *self, PyObject *args)
+{ EMPTY_METHOD; }
+static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *args)
 { EMPTY_METHOD; }
 
 #endif
@@ -769,6 +796,7 @@ PyMethodDef module_fontforge_ui_methods[] = {
    { "getGtkWindowMainEventLoopFD", (PyCFunction) PyFFFont_getGtkWindowMainEventLoopFD, METH_VARARGS, "fixme." },
    { "removeGtkWindowToMainEventLoop", (PyCFunction) PyFFFont_removeGtkWindowToMainEventLoop, METH_VARARGS, "fixme." },
    { "removeGtkWindowToMainEventLoopByFD", (PyCFunction) PyFFFont_removeGtkWindowToMainEventLoopByFD, METH_VARARGS, "fixme." },
+   { "addWindow", (PyCFunction) PyFFFont_addWindow, METH_VARARGS, "Adds gtk window to event loop" },
 
    
    PYMETHODDEF_EMPTY /* Sentinel */

--- a/fontforgeexe/pythonui.c
+++ b/fontforgeexe/pythonui.c
@@ -691,7 +691,7 @@ static PyObject *PyFFFont_removeGtkWindowToMainEventLoopByFD(PyFF_Font *self, Py
 }
 
 static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *UNUSED(args)) {
-	PyObject *w;
+	FontView *fv = (FontView *) self->fv;
 
 	/*PyErr_Format(PyExc_EnvironmentError, "FontForge not compiled with GTK extension");
 	return( NULL );*/
@@ -701,7 +701,7 @@ static PyObject *PyFFFont_addWindow(PyFF_Font *self, PyObject *UNUSED(args)) {
 		return( NULL );
 	}*/
 
-	gtkb_addWindow();
+	gtkb_AddWindow(fv->gw);
 	/*gboolean may_block = false;
 	GMainContext *con = g_main_context_default();
 	while (g_main_context_pending(con))
@@ -784,6 +784,7 @@ PyMethodDef PyFF_FontUI_methods[] = {
    { "CollabLastChangedPos", (PyCFunction) PyFF_getLastChangedPos, METH_VARARGS, "" },
    { "CollabLastChangedCodePoint", (PyCFunction) PyFF_getLastChangedCodePoint, METH_VARARGS, "" },
    { "CollabLastSeq", (PyCFunction) PyFF_getLastSeq, METH_VARARGS, "" },
+   { "addWindow", (PyCFunction) PyFFFont_addWindow, METH_VARARGS, "Adds gtk window to event loop" },
 
    
    PYMETHODDEF_EMPTY /* Sentinel */
@@ -796,7 +797,6 @@ PyMethodDef module_fontforge_ui_methods[] = {
    { "getGtkWindowMainEventLoopFD", (PyCFunction) PyFFFont_getGtkWindowMainEventLoopFD, METH_VARARGS, "fixme." },
    { "removeGtkWindowToMainEventLoop", (PyCFunction) PyFFFont_removeGtkWindowToMainEventLoop, METH_VARARGS, "fixme." },
    { "removeGtkWindowToMainEventLoopByFD", (PyCFunction) PyFFFont_removeGtkWindowToMainEventLoopByFD, METH_VARARGS, "fixme." },
-   { "addWindow", (PyCFunction) PyFFFont_addWindow, METH_VARARGS, "Adds gtk window to event loop" },
 
    
    PYMETHODDEF_EMPTY /* Sentinel */

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -42,7 +42,7 @@ libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c	\
 	gimagebmpP.h gresourceP.h gxcdrawP.h fontP.h ggadgetP.h		\
 	gpsdrawP.h gwidgetP.h gxdrawP.h hotkeys.c hotkeys.h		\
 	div_tables.c ggdkdraw.c ggdkcdraw.c ggdkdrawlogger.c            \
-	gtkbridge.c ggdkdrawP.h
+	gtkbbr.c gtkbridge.c ggdkdrawP.h
 
 libgdraw_la_LIBADD =
 

--- a/gdraw/Makefile.am
+++ b/gdraw/Makefile.am
@@ -41,7 +41,8 @@ libgdraw_la_SOURCES = choosericons.c ctlvalues.c drawboxborder.c	\
 	gdrawable.c gspacer.c xkeysyms_unicode.c colorP.h gdrawP.h	\
 	gimagebmpP.h gresourceP.h gxcdrawP.h fontP.h ggadgetP.h		\
 	gpsdrawP.h gwidgetP.h gxdrawP.h hotkeys.c hotkeys.h		\
-	div_tables.c ggdkdraw.c ggdkcdraw.c ggdkdrawlogger.c ggdkdrawP.h
+	div_tables.c ggdkdraw.c ggdkcdraw.c ggdkdrawlogger.c            \
+	gtkbridge.c ggdkdrawP.h
 
 libgdraw_la_LIBADD =
 

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -192,12 +192,15 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
 
     if (!gw->is_pixmap) {
         if (gw != gw->display->groot) {
-            while (gw->transient_childs->len > 0) {
-                GGDKWindow tw = (GGDKWindow)g_ptr_array_remove_index_fast(gw->transient_childs, gw->transient_childs->len - 1);
-                gdk_window_set_transient_for(tw->w, gw->display->groot->w);
-                tw->transient_owner = NULL;
-                tw->istransient = false;
-            }
+			for (int i = ((int)gw->display->transient_stack->len) - 1; i >= 0; --i) {
+				GGDKWindow tw = (GGDKWindow)gw->display->transient_stack->pdata[i];
+				if (tw->transient_owner == gw) {
+					g_ptr_array_remove_index(gw->display->transient_stack, i);
+					gdk_window_set_transient_for(tw->w, gw->display->groot->w);
+					tw->transient_owner = NULL;
+					tw->istransient = false;
+				}
+			}
 
             if (!gdk_window_is_destroyed(gw->w)) {
                 gdk_window_destroy(gw->w);
@@ -251,7 +254,6 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
         Log(LOGDEBUG, "Window destroyed: %p[%p][%s][%d]", gw, gw->w, gw->window_title, gw->is_toplevel);
         free(gw->window_title);
         if (gw != gw->display->groot) {
-            g_ptr_array_free(gw->transient_childs, true);
             // Unreference our reference to the window
             g_object_unref(G_OBJECT(gw->w));
         }
@@ -612,9 +614,6 @@ static GWindow _GGDKDraw_CreateWindow(GGDKDisplay *gdisp, GGDKWindow gw, GRect *
         GGDKDrawSetCursor((GWindow)nw, wattrs->cursor);
     }
 
-    // TODO: Add error checking?
-    nw->transient_childs = g_ptr_array_sized_new(5);
-
     // Add a reference to our own structure.
     GGDKDRAW_ADDREF(nw);
 
@@ -769,8 +768,6 @@ static int _GGDKDraw_WindowOrParentsDying(GGDKWindow gw) {
 }
 
 static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
-    GGDKWindow gww = gw;
-
     switch (event->type) {
         case GDK_KEY_PRESS:
         case GDK_KEY_RELEASE:
@@ -785,27 +782,27 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
             break;
     }
 
-    while (gww != gw->display->groot) {
-        if (gww->transient_childs->len > 0) {
-            bool has_modal = false;
-            for (guint i = 0; i < gww->transient_childs->len; i++) {
-                GGDKWindow ow = (GGDKWindow)gww->transient_childs->pdata[i];
-                if (ow->restrict_input_to_me) {
-                    has_modal = true;
-                    break;
-                }
-            }
-            if (has_modal) {
-                break;
-            }
-        }
-        gww = gww->parent;
-    }
+	GGDKWindow gww = gw;
+    GPtrArray *stack = gw->display->transient_stack;
 
-    if (gww == gw->display->groot) {
-        return false;
-    }
+    while (gww != NULL) {
+		GGDKWindow last_modal = NULL;
 
+		for (int i = ((int)stack->len)-1; i >= 0; --i) {
+			GGDKWindow ow = (GGDKWindow)stack->pdata[i];
+			if (ow == gww || ow->restrict_input_to_me) { // fudged
+				last_modal = ow;
+				break;
+			}
+		}
+		
+		if (last_modal == NULL || last_modal == gww) {
+			return false;
+		}
+		
+		gww = gww->parent;
+	}
+	
     if (event->type != GDK_MOTION_NOTIFY && event->type != GDK_BUTTON_RELEASE) {
         gdk_window_beep(gw->w);
     }
@@ -1566,20 +1563,19 @@ static void GGDKDrawSetTransientFor(GWindow transient, GWindow owner) {
         ow = (GGDKWindow)owner;
     }
 
-    if (gw->transient_owner != NULL) {
-        g_ptr_array_remove_fast(gw->transient_owner->transient_childs, gw);
-    }
-
     if (ow != NULL) {
         gdk_window_set_transient_for(gw->w, ow->w);
         gdk_window_set_modal_hint(gw->w, true);
         gw->istransient = true;
 
-        g_ptr_array_add(ow->transient_childs, gw);
+		g_ptr_array_add(gdisp->transient_stack, gw);
     } else {
         gdk_window_set_modal_hint(gw->w, false);
         gdk_window_set_transient_for(gw->w, gw->display->groot->w);
         gw->istransient = false;
+        
+        // TODO: optimise; search from the back; it is meant to be a stack...
+        g_ptr_array_remove(gdisp->transient_stack, gw);
     }
 
     gw->transient_owner = ow;
@@ -2476,6 +2472,7 @@ GDisplay *_GGDKDraw_CreateDisplay(char *displayname, char *UNUSED(programname)) 
         free(gdisp);
         return NULL;
     }
+    gdisp->transient_stack = g_ptr_array_sized_new(5);
 
     gdisp->funcs = &gdkfuncs;
     gdisp->display = display;
@@ -2595,6 +2592,8 @@ void _GGDKDraw_DestroyDisplay(GDisplay *disp) {
     // Finally destroy the window table
     g_hash_table_destroy(gdisp->windows);
     gdisp->windows = NULL;
+    
+    g_ptr_array_free(gdisp->transient_stack, true);
 
     // Destroy held selection types, if any
     free(gdisp->seltypes.types);

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -173,7 +173,7 @@ static bool _GGDKDraw_TransmitSelection(GGDKDisplay *gdisp, GdkEventSelection *e
     return true;
 }
 
-static void GGDK_ChangeRestrictCount(GGDKDisplay *gdisp, int c) {
+static void _GGDKDraw_ChangeRestrictCount(GGDKDisplay *gdisp, int c) {
     gdisp->restrict_count += c;
 
     printf("Restrict Count: %d\n", gdisp->restrict_count);
@@ -205,18 +205,17 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
 
     if (!gw->is_pixmap) {
         if (gw != gw->display->groot) {
-			for (int i = ((int)gw->display->transient_stack->len) - 1; i >= 0; --i) {
-				GGDKWindow tw = (GGDKWindow)gw->display->transient_stack->pdata[i];
-				if (tw->transient_owner == gw) {
-					g_ptr_array_remove_index(gw->display->transient_stack, i);
-					gdk_window_set_transient_for(tw->w, gw->display->groot->w);
-					tw->transient_owner = NULL;
-					tw->istransient = false;
-					if ( tw->restrict_input_to_me )
-					    GGDK_ChangeRestrictCount(gw->display, -1);
-				}
-			}
-
+            for (int i = ((int)gw->display->transient_stack->len) - 1; i >= 0; --i) {
+                GGDKWindow tw = (GGDKWindow)gw->display->transient_stack->pdata[i];
+                if (tw->transient_owner == gw) {
+                    g_ptr_array_remove_index(gw->display->transient_stack, i);
+                    gdk_window_set_transient_for(tw->w, gw->display->groot->w);
+                    tw->transient_owner = NULL;
+                    tw->istransient = false;
+                    if (tw->restrict_input_to_me)
+                        _GGDKDraw_ChangeRestrictCount(gw->display, -1);
+                    }
+            }
             if (!gdk_window_is_destroyed(gw->w)) {
                 gdk_window_destroy(gw->w);
                 // Wait for it to die
@@ -789,7 +788,6 @@ static int _GGDKDraw_WindowOrParentsDying(GGDKWindow gw) {
 }
 
 static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
-
     switch (event->type) {
         case GDK_KEY_PRESS:
         case GDK_KEY_RELEASE:
@@ -806,16 +804,6 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
 
     GGDKWindow gww = gw;
     GPtrArray *stack = gw->display->transient_stack;
-
-#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
-    if ( gtkb_Grabbed(gww->display->gtkb_state) ) {
-	// If gtk has an active grab, push the (already filtered)
-	// event up to it.
-	gtkb_ProcessEvent(gww->display->gtkb_state, event);
-	// Keep the "beep" (XXX?)
-	gww = NULL;
-    }
-#endif
 
     if ( gww && gw->display->restrict_count == 0 )
 	return false;
@@ -1616,7 +1604,7 @@ static void GGDKDrawSetTransientFor(GWindow transient, GWindow owner) {
         gw->istransient = true;
 	g_ptr_array_add(gdisp->transient_stack, gw);
 	if (gw->restrict_input_to_me)
-	    GGDK_ChangeRestrictCount(gdisp, 1);
+	    _GGDKDraw_ChangeRestrictCount(gdisp, 1);
     } else {
         gdk_window_set_modal_hint(gw->w, false);
         gdk_window_set_transient_for(gw->w, gw->display->groot->w);
@@ -1626,7 +1614,7 @@ static void GGDKDrawSetTransientFor(GWindow transient, GWindow owner) {
 	// case there are spurious remove calls.
         // TODO: optimise; search from the back; it is meant to be a stack...
         if ( g_ptr_array_remove(gdisp->transient_stack, gw) && gw->restrict_input_to_me )
-	    GGDK_ChangeRestrictCount(gdisp, -1);
+	    _GGDKDraw_ChangeRestrictCount(gdisp, -1);
     }
 
     gw->transient_owner = ow;

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -214,7 +214,7 @@ static gboolean _GGDKDraw_OnWindowDestroyed(gpointer data) {
                     tw->istransient = false;
                     if (tw->restrict_input_to_me)
                         _GGDKDraw_ChangeRestrictCount(gw->display, -1);
-                    }
+                }
             }
             if (!gdk_window_is_destroyed(gw->w)) {
                 gdk_window_destroy(gw->w);

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -806,25 +806,25 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
     GPtrArray *stack = gw->display->transient_stack;
 
     if ( gww && gw->display->restrict_count == 0 )
-	return false;
+        return false;
 
     while (gww != NULL) {
-		GGDKWindow last_modal = NULL;
+        GGDKWindow last_modal = NULL;
 
-		for (int i = ((int)stack->len)-1; i >= 0; --i) {
-			GGDKWindow ow = (GGDKWindow)stack->pdata[i];
-			if (ow == gww || ow->restrict_input_to_me) { // fudged
-				last_modal = ow;
-				break;
-			}
-		}
+        for (int i = ((int)stack->len)-1; i >= 0; --i) {
+            GGDKWindow ow = (GGDKWindow)stack->pdata[i];
+            if (ow == gww || ow->restrict_input_to_me) { // fudged
+                last_modal = ow;
+                break;
+            }
+        }
 
-		if (last_modal == NULL || last_modal == gww) {
-			return false;
-		}
+        if (last_modal == NULL || last_modal == gww) {
+            return false;
+        }
 
-		gww = gww->parent;
-	}
+        gww = gww->parent;
+    }
 
     if (event->type != GDK_MOTION_NOTIFY && event->type != GDK_BUTTON_RELEASE) {
         gdk_window_beep(gw->w);
@@ -1018,7 +1018,7 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
                         gw == gdisp->bs.release_w &&
                         gevent.u.mouse.button == gdisp->bs.release_button &&
                         (int32_t)(gevent.u.mouse.time - gdisp->bs.last_press_time) < gdisp->bs.double_time &&
-                        gevent.u.mouse.time >= gdisp->bs.last_press_time) {	// Time can wrap
+                        gevent.u.mouse.time >= gdisp->bs.last_press_time) {  // Time can wrap
 
                     gdisp->bs.cur_click++;
                 } else {
@@ -1602,19 +1602,19 @@ static void GGDKDrawSetTransientFor(GWindow transient, GWindow owner) {
         gdk_window_set_transient_for(gw->w, ow->w);
         gdk_window_set_modal_hint(gw->w, true);
         gw->istransient = true;
-	g_ptr_array_add(gdisp->transient_stack, gw);
-	if (gw->restrict_input_to_me)
-	    _GGDKDraw_ChangeRestrictCount(gdisp, 1);
+        g_ptr_array_add(gdisp->transient_stack, gw);
+        if (gw->restrict_input_to_me)
+            _GGDKDraw_ChangeRestrictCount(gdisp, 1);
     } else {
         gdk_window_set_modal_hint(gw->w, false);
         gdk_window_set_transient_for(gw->w, gw->display->groot->w);
         gw->istransient = false;
 
-	// Be extra careful and ensure the window was on the list, in
-	// case there are spurious remove calls.
+        // Be extra careful and ensure the window was on the list, in
+        // case there are spurious remove calls.
         // TODO: optimise; search from the back; it is meant to be a stack...
         if ( g_ptr_array_remove(gdisp->transient_stack, gw) && gw->restrict_input_to_me )
-	    _GGDKDraw_ChangeRestrictCount(gdisp, -1);
+            _GGDKDraw_ChangeRestrictCount(gdisp, -1);
     }
 
     gw->transient_owner = ow;

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -810,12 +810,12 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
 #ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
     if ( gtkb_Grabbed(gww->display->gtkb_state) ) {
 	// If gtk has an active grab, push the (already filtered)
-	// event up to it. 
+	// event up to it.
 	gtkb_ProcessEvent(gww->display->gtkb_state, event);
 	// Keep the "beep" (XXX?)
 	gww = NULL;
     }
-#endif 
+#endif
 
     if ( gww && gw->display->restrict_count == 0 )
 	return false;
@@ -830,14 +830,14 @@ static bool _GGDKDraw_FilterByModal(GdkEvent *event, GGDKWindow gw) {
 				break;
 			}
 		}
-		
+
 		if (last_modal == NULL || last_modal == gww) {
 			return false;
 		}
-		
+
 		gww = gww->parent;
 	}
-	
+
     if (event->type != GDK_MOTION_NOTIFY && event->type != GDK_BUTTON_RELEASE) {
         gdk_window_beep(gw->w);
     }

--- a/gdraw/ggdkdraw.c
+++ b/gdraw/ggdkdraw.c
@@ -33,6 +33,7 @@
 #include "gresource.h"
 #include "gkeysym.h"
 #include "ustring.h"
+#include "gtkbridge.h"
 #include <assert.h>
 #include <string.h>
 #include <math.h>
@@ -862,6 +863,9 @@ static void _GGDKDraw_DispatchEvent(GdkEvent *event, gpointer data) {
         return;
     } else if ((gw = g_object_get_data(G_OBJECT(w), "GGDKWindow")) == NULL) {
         //Log(LOGDEBUG, "MISSING GW!");
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+	gtkb_do_event(event);
+#endif
         return;
     } else if (_GGDKDraw_WindowOrParentsDying(gw) || gdk_window_is_destroyed(w)) {
         Log(LOGDEBUG, "DYING! %p", w);

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -218,6 +218,7 @@ typedef struct ggdkdisplay { /* :GDisplay */
     GGDKKeyState ks;
     GGDKWindow default_icon;
     GGDKWindow last_nontransient_window;
+    GPtrArray *transient_stack; // When can a transient window have a transient child?
 
     GMainLoop  *main_loop;
     GdkDisplay *display;
@@ -263,7 +264,6 @@ struct ggdkwindow { /* :GWindow */
     unsigned int has_had_faked_configure: 1;
 
     int reference_count; // Knowing when to destroy is tricky...
-    GPtrArray *transient_childs; // Handling transients is tricky...
     guint resize_timeout; // Resizing is tricky...
 
     GWindow redirect_from;		/* only redirect input from this window and its children */

--- a/gdraw/ggdkdrawP.h
+++ b/gdraw/ggdkdrawP.h
@@ -219,11 +219,16 @@ typedef struct ggdkdisplay { /* :GDisplay */
     GGDKWindow default_icon;
     GGDKWindow last_nontransient_window;
     GPtrArray *transient_stack; // When can a transient window have a transient child?
+    int restrict_count;
 
     GMainLoop  *main_loop;
     GdkDisplay *display;
     GdkScreen  *screen;
     GdkWindow  *root;
+
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+    FFGtkBState *gtkb_state;
+#endif
 
     PangoContext *pangoc_context;
 } GGDKDisplay;

--- a/gdraw/gtkbbr.c
+++ b/gdraw/gtkbbr.c
@@ -1,0 +1,16 @@
+#include "basics.h"
+#include "gdraw/ggdkdrawP.h"
+#include "gdraw/gtkbridge.h"
+
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+
+void gtkb_AddWindow(GWindow gw) {
+	GGDKWindow ggdkw = (GGDKWindow) gw;
+	GdkWindow *gdkw = (GdkWindow *) ggdkw->w;
+	GGDKDisplay *gdisp = ggdkw->display;
+	//printf("Pointers: %p %p\n", ggw, gdkw);
+	printf("Pointers: %p\n", gdkw);
+	_gtkb_AddWindow(gdisp->gtkb_state, gdkw);
+}
+
+#endif // FONTFORGE_CAN_USE_GTK_BRIDGE

--- a/gdraw/gtkbridge.c
+++ b/gdraw/gtkbridge.c
@@ -2,6 +2,7 @@
 
 #ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
 #include <gtk/gtk.h>
+#include <gmodule.h>
 
 struct ffgtkb_state {
 	GtkWindow *event_trap_win, *the_window;
@@ -111,6 +112,7 @@ static GtkWidget *make_window(FFGtkBState *state, GdkWindow *w) {
 	gtk_window_set_title (GTK_WINDOW (window), "Window");
 	gtk_window_set_default_size (GTK_WINDOW (window), 200, 200);
 	g_signal_connect(window, "destroy", G_CALLBACK (gtkb_TheWindowDestroy), (gpointer) state);
+	gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
 
 	button_box = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
 	gtk_container_add(GTK_CONTAINER (window), button_box);
@@ -136,6 +138,15 @@ void gtkb_ProcessEvent(FFGtkBState *state, GdkEvent *event) {
 	if (state != NULL)
 		gtk_main_do_event(event);
 }
+
+void gtkb_SetDefaultIcon(FFGtkBState *state, GdkPixbuf *pb) {
+	if (pb != NULL) {
+		GList ent = { .data = pb };
+		gtk_window_set_default_icon_list(&ent);
+		g_object_unref(pb);
+	}
+}
+
 
 #endif // FONTFORGE_CAN_USE_GTK_BRIDGE
 

--- a/gdraw/gtkbridge.c
+++ b/gdraw/gtkbridge.c
@@ -7,12 +7,26 @@ static void print_hello(GtkWidget *widget, gpointer data) {
 	printf ("Hello World\n");
 }
 
-static GtkWidget *make_window(GtkApplication* app, gpointer user_data) {
+static void modal_win(GtkWidget *widget, gpointer data) {
+	GtkWidget *dialog, *label, *content_area;
+
+	GtkDialogFlags flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
+	dialog = gtk_dialog_new_with_buttons("My dialog", GTK_WINDOW(widget), flags,
+	         "_OK", GTK_RESPONSE_ACCEPT, "_Cancel", GTK_RESPONSE_REJECT, NULL);
+
+	content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
+	label = gtk_label_new("This is a message");
+	g_signal_connect_swapped(dialog, "response", G_CALLBACK(gtk_widget_destroy), dialog);
+	gtk_container_add(GTK_CONTAINER(content_area), label);
+	gtk_widget_show_all(dialog);
+}
+
+static GtkWidget *make_window() {
 	GtkWidget *window;
 	GtkWidget *button;
 	GtkWidget *button_box;
 
-	window = gtk_application_window_new (app);
+	window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_window_set_title (GTK_WINDOW (window), "Window");
 	gtk_window_set_default_size (GTK_WINDOW (window), 200, 200);
 
@@ -20,14 +34,26 @@ static GtkWidget *make_window(GtkApplication* app, gpointer user_data) {
 	gtk_container_add(GTK_CONTAINER (window), button_box);
 
 	button = gtk_button_new_with_label ("Hello World");
-	g_signal_connect (button, "clicked", G_CALLBACK (print_hello), NULL);
+	//g_signal_connect (button, "clicked", G_CALLBACK (print_hello), NULL);
+	g_signal_connect (button, "clicked", G_CALLBACK (modal_win), NULL);
 	// g_signal_connect_swapped (button, "clicked", G_CALLBACK (gtk_widget_destroy), window);
 	gtk_container_add (GTK_CONTAINER (button_box), button);
 
 	gtk_widget_show_all (window);
 }
 
-static void gtkb_addWindow() {
+static GtkWidget *the_window;
+
+void gtkb_addWindow() {
+	if (the_window == NULL) {
+		//gtk_init(0,NULL);
+		the_window = make_window();
+	}
+}
+
+void gtkb_do_event(GdkEvent *event) {
+	if (the_window != NULL)
+		gtk_main_do_event(event);
 }
 
 #endif // FONTFORGE_CAN_USE_GTK_BRIDGE

--- a/gdraw/gtkbridge.c
+++ b/gdraw/gtkbridge.c
@@ -1,0 +1,34 @@
+#include "basics.h"
+
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+#include <gtk/gtk.h>
+
+static void print_hello(GtkWidget *widget, gpointer data) {
+	printf ("Hello World\n");
+}
+
+static GtkWidget *make_window(GtkApplication* app, gpointer user_data) {
+	GtkWidget *window;
+	GtkWidget *button;
+	GtkWidget *button_box;
+
+	window = gtk_application_window_new (app);
+	gtk_window_set_title (GTK_WINDOW (window), "Window");
+	gtk_window_set_default_size (GTK_WINDOW (window), 200, 200);
+
+	button_box = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
+	gtk_container_add(GTK_CONTAINER (window), button_box);
+
+	button = gtk_button_new_with_label ("Hello World");
+	g_signal_connect (button, "clicked", G_CALLBACK (print_hello), NULL);
+	// g_signal_connect_swapped (button, "clicked", G_CALLBACK (gtk_widget_destroy), window);
+	gtk_container_add (GTK_CONTAINER (button_box), button);
+
+	gtk_widget_show_all (window);
+}
+
+static void gtkb_addWindow() {
+}
+
+#endif // FONTFORGE_CAN_USE_GTK_BRIDGE
+

--- a/gdraw/gtkbridge.c
+++ b/gdraw/gtkbridge.c
@@ -3,15 +3,94 @@
 #ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
 #include <gtk/gtk.h>
 
+struct ffgtkb_state {
+	GtkWindow *event_trap_win, *the_window;
+	bool grabbed, grabbing;
+};
+typedef struct ffgtkb_state FFGtkBState;
+
 static void print_hello(GtkWidget *widget, gpointer data) {
 	printf ("Hello World\n");
+}
+
+bool gtkb_Grabbed(FFGtkBState *state) {
+	if (state == NULL)
+		return false;
+
+	return state->grabbed;
+}
+
+void gtkb_Grab(FFGtkBState *state, bool grab) {
+	if (state == NULL || state->grabbing == grab)
+		return;
+
+	if (state->grabbing) {
+		gtk_grab_remove(GTK_WIDGET(state->event_trap_win));
+		state->grabbing = false;
+		printf("Unrabbing GTK\n");
+	} else {
+		gtk_grab_add(GTK_WIDGET(state->event_trap_win));
+		state->grabbing = true;
+		printf("Grabbing GTK\n");
+	}
+}
+
+static void gtkb_GrabTrack(GtkWidget *widget, gboolean was_grabbed, gpointer data) {
+	FFGtkBState *state = (FFGtkBState *) data;
+
+	if (state == NULL) // Should never happen
+		return;
+
+	printf("notify_grab: %s\n", was_grabbed ? "True" : "False");
+	state->grabbed = ! was_grabbed;
+}
+
+static void gtkb_TheWindowDestroy(GtkWidget *widget, gpointer data) {
+	FFGtkBState *state = (FFGtkBState *) data;
+
+	if (state == NULL) // Should never happen
+		return;
+
+	state->the_window = NULL;
+}
+
+FFGtkBState *gtkb_CreateState() {
+	FFGtkBState *state;
+	GtkWidget *window;
+	GtkWidget *eb;
+
+	state = (FFGtkBState *)calloc(1, sizeof(FFGtkBState));
+
+	// Allocate event-trap window (will never be made visible)
+	window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+	eb = gtk_event_box_new();
+	gtk_widget_set_sensitive(eb, true);
+	gtk_container_add(GTK_CONTAINER (window), eb);
+	g_signal_connect(eb, "grab-notify", G_CALLBACK (gtkb_GrabTrack), (gpointer) state);
+	gtk_widget_realize(window);
+
+	state->event_trap_win = GTK_WINDOW(window);
+	return state;
+}
+
+void gtkb_DestroyState(FFGtkBState *state) {
+
+	if (state->the_window != NULL) {
+		gtk_widget_destroy(GTK_WIDGET(state->the_window));
+		state->the_window = NULL;
+	}
+
+	gtk_widget_destroy(GTK_WIDGET(state->event_trap_win));
+	state->event_trap_win = NULL;
+
+	free(state);
 }
 
 static void modal_win(GtkWidget *widget, gpointer data) {
 	GtkWidget *dialog, *label, *content_area;
 
 	GtkDialogFlags flags = GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT;
-	dialog = gtk_dialog_new_with_buttons("My dialog", GTK_WINDOW(widget), flags,
+	dialog = gtk_dialog_new_with_buttons("My dialog", GTK_WINDOW(gtk_widget_get_toplevel(widget)), flags,
 	         "_OK", GTK_RESPONSE_ACCEPT, "_Cancel", GTK_RESPONSE_REJECT, NULL);
 
 	content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
@@ -21,14 +100,17 @@ static void modal_win(GtkWidget *widget, gpointer data) {
 	gtk_widget_show_all(dialog);
 }
 
-static GtkWidget *make_window() {
+// Test window 
+static GtkWidget *make_window(FFGtkBState *state, GdkWindow *w) {
 	GtkWidget *window;
+	GtkWidget *eb;
 	GtkWidget *button;
 	GtkWidget *button_box;
 
 	window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_window_set_title (GTK_WINDOW (window), "Window");
 	gtk_window_set_default_size (GTK_WINDOW (window), 200, 200);
+	g_signal_connect(window, "destroy", G_CALLBACK (gtkb_TheWindowDestroy), (gpointer) state);
 
 	button_box = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
 	gtk_container_add(GTK_CONTAINER (window), button_box);
@@ -40,19 +122,18 @@ static GtkWidget *make_window() {
 	gtk_container_add (GTK_CONTAINER (button_box), button);
 
 	gtk_widget_show_all (window);
+	// gdk_window_set_group(gtk_widget_get_window(window), gdk_window_get_group(w));
+	return window;
 }
 
-static GtkWidget *the_window;
-
-void gtkb_addWindow() {
-	if (the_window == NULL) {
-		//gtk_init(0,NULL);
-		the_window = make_window();
+void _gtkb_AddWindow(FFGtkBState *state, GdkWindow *pseudo_parent) {
+	if (state != NULL && state->the_window == NULL) {
+		state->the_window = GTK_WINDOW(make_window(state, pseudo_parent));
 	}
 }
 
-void gtkb_do_event(GdkEvent *event) {
-	if (the_window != NULL)
+void gtkb_ProcessEvent(FFGtkBState *state, GdkEvent *event) {
+	if (state != NULL)
 		gtk_main_do_event(event);
 }
 

--- a/gdraw/gtkbridge.c
+++ b/gdraw/gtkbridge.c
@@ -104,9 +104,7 @@ static void modal_win(GtkWidget *widget, gpointer data) {
 // Test window 
 static GtkWidget *make_window(FFGtkBState *state, GdkWindow *w) {
 	GtkWidget *window;
-	GtkWidget *eb;
-	GtkWidget *button;
-	GtkWidget *button_box;
+	GtkWidget *vbox, *view, *button, *button_box;
 
 	window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
 	gtk_window_set_title (GTK_WINDOW (window), "Window");
@@ -114,14 +112,21 @@ static GtkWidget *make_window(FFGtkBState *state, GdkWindow *w) {
 	g_signal_connect(window, "destroy", G_CALLBACK (gtkb_TheWindowDestroy), (gpointer) state);
 	gtk_window_set_position(GTK_WINDOW(window), GTK_WIN_POS_CENTER);
 
+	vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+	view = gtk_text_view_new();
+	gtk_box_pack_start(GTK_BOX(vbox), view, TRUE, TRUE, 0);
+
 	button_box = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
-	gtk_container_add(GTK_CONTAINER (window), button_box);
+	gtk_box_pack_start(GTK_BOX(vbox), button_box, TRUE, TRUE, 0);
+
 
 	button = gtk_button_new_with_label ("Hello World");
 	//g_signal_connect (button, "clicked", G_CALLBACK (print_hello), NULL);
 	g_signal_connect (button, "clicked", G_CALLBACK (modal_win), NULL);
 	// g_signal_connect_swapped (button, "clicked", G_CALLBACK (gtk_widget_destroy), window);
 	gtk_container_add (GTK_CONTAINER (button_box), button);
+
+	gtk_container_add(GTK_CONTAINER (window), vbox);
 
 	gtk_widget_show_all (window);
 	// gdk_window_set_group(gtk_widget_get_window(window), gdk_window_get_group(w));

--- a/gdraw/gtkbridge.h
+++ b/gdraw/gtkbridge.h
@@ -25,4 +25,11 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+
+#include <ffgdk.h>
+
 extern void gtkb_addWindow();
+extern void gtkb_do_event(GdkEvent *event);
+
+#endif // FONTFORGE_CAN_USE_GTK_BRIDGE

--- a/gdraw/gtkbridge.h
+++ b/gdraw/gtkbridge.h
@@ -28,6 +28,7 @@
 #ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
 
 #include <ffgdk.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
 
 extern FFGtkBState *gtkb_CreateState();
 extern void gtkb_DestroyState(FFGtkBState *state);
@@ -36,5 +37,6 @@ extern bool gtkb_Grabbed(FFGtkBState *state);
 extern void gtkb_Grab(FFGtkBState *state, bool grab);
 extern void gtkb_AddWindow(GWindow fv);
 extern void _gtkb_AddWindow(FFGtkBState *state, GdkWindow *gw);
+extern void gtkb_SetDefaultIcon(FFGtkBState *state, GdkPixbuf *pb);
 
 #endif // FONTFORGE_CAN_USE_GTK_BRIDGE

--- a/gdraw/gtkbridge.h
+++ b/gdraw/gtkbridge.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2019 by Skef Iterum */
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+
+ * The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+extern void gtkb_addWindow();

--- a/gdraw/gtkbridge.h
+++ b/gdraw/gtkbridge.h
@@ -29,7 +29,12 @@
 
 #include <ffgdk.h>
 
-extern void gtkb_addWindow();
-extern void gtkb_do_event(GdkEvent *event);
+extern FFGtkBState *gtkb_CreateState();
+extern void gtkb_DestroyState(FFGtkBState *state);
+extern void gtkb_ProcessEvent(FFGtkBState *state, GdkEvent *event);
+extern bool gtkb_Grabbed(FFGtkBState *state);
+extern void gtkb_Grab(FFGtkBState *state, bool grab);
+extern void gtkb_AddWindow(GWindow fv);
+extern void _gtkb_AddWindow(FFGtkBState *state, GdkWindow *gw);
 
 #endif // FONTFORGE_CAN_USE_GTK_BRIDGE

--- a/inc/ffgdk.h
+++ b/inc/ffgdk.h
@@ -41,5 +41,10 @@
 #undef GList
 #undef GTimer
 
+#ifdef FONTFORGE_CAN_USE_GTK_BRIDGE
+struct ffgtkb_state;
+typedef struct ffgtkb_state FFGtkBState;
+#endif // FONTFORGE_CAN_USE_GTK_BRIDGE
+
 #endif // FONTFORGE_CAN_USE_GDK
 #endif // _FFGDK_H

--- a/m4/fontforge_arg_enable.m4
+++ b/m4/fontforge_arg_enable.m4
@@ -239,6 +239,45 @@ fi
 AM_CONDITIONAL([FONTFORGE_CAN_USE_GDK],[test x"${fontforge_can_use_gdk}" = xyes])
 ])
 
+dnl FONTFORGE_ARG_ENABLE_GTK_BRIDGE
+dnl ------------------------
+AC_DEFUN([FONTFORGE_ARG_ENABLE_GTK_BRIDGE],
+[
+fontforge_gtk_version=no
+AC_ARG_ENABLE([gtk-bridge],
+        [AS_HELP_STRING([--enable-gtk-bridge],
+                [Enable the GTK window extension.])],
+        [use_gtk_bridge=yes])
+if test x$use_gtk_bridge = xyes ; then
+    if test "x$enableval" = "xgtk2"; then
+        PKG_CHECK_MODULES([GTK], [gtk+-2.0 >= 2.10],
+        [
+            fontforge_can_use_gtk_bridge=yes
+            fontforge_gtk_version=GTK2
+            AC_DEFINE(FONTFORGE_CAN_USE_GTK_BRIDGE,[],[FontForge will enable the GTK window extension])
+            AC_MSG_NOTICE([building the GTK extension with the GTK2 backend...])
+        ],
+        [
+            AC_MSG_ERROR([Cannot build GTK extension without GTK installed. Please install the GTK+ Developer Package.])
+        ])
+    else
+        PKG_CHECK_MODULES([GTK],[gtk+-3.0 >= 3.10],
+        [
+            fontforge_can_use_gtk_bridge=yes
+            fontforge_gtk_version=GTK3
+            AC_DEFINE(FONTFORGE_CAN_USE_GTK_BRIDGE,[],[FontForge will enable the GTK3 window extension])
+            AC_MSG_NOTICE([building the GTK extension with the GDK3 backend...])
+        ],
+        [
+            AC_MSG_ERROR([Cannot build GTK backend without GTK installed. Please install the GTK+ Developer Package.])
+        ])
+    fi
+else
+    fontforge_can_use_gtk_bridge=no
+fi
+AM_CONDITIONAL([FONTFORGE_CAN_USE_GTK_BRIDGE],[test x"${fontforge_can_use_gtk_bridge}" = xyes])
+])
+
 dnl FONTFORGE_ARG_ENABLE_WOFF2
 dnl ------------------------
 AC_DEFUN([FONTFORGE_ARG_ENABLE_WOFF2],


### PR DESCRIPTION
This isn't really a request -- just a context for discussion. 

This is my current gtk bridge code. Configure with `--enable-gdk --enable-gtk-bridge` . I haven't verified a lot of things, including whether the gxdraw version still compiles correctly. I also don't know what this will do under, for example, Windows. 

After building throw a file with this content in your `.config/fontforge/python` directory:
```
import fontforge

fontforge.registerMenuItem(lambda x,y: y.addWindow(), None, None, "Font", None, "Add Window")
```

Then run `Tools -> Add Window` from some font window. 

Note that:

1. Cross-modality works
2. The created windows go into the same window manager slot (under X). 
3. The icon decorations aren't quite right, but close. 
4. And most importantly inspect `gdraw/gtkbridge.c:make_window` and note that it isn't doing anything "custom". GTK pretty much works "as advertised". 

There are two directions to go with a stable version of this:

1. Gradually throw various windows and dialogs "over the fence". This need not be a process that ever completes (although it sounds like you anticipate GDK4 being a problem). The obvious low-hanging fruit here are the file dialogs. I would actually advocate doing a minimal set with at least those not so much because I think it's needed, but to stave off bit rot. Collab rotted away and anything like this could too without ongoing care. On the other hand, GTK and GDK are sufficiently well-associated that I suspect any bug that came up could be addessed in one way or another*.
2. Allowing python GTK UI extension. That would sort of work with what I have now. However, if we want to support longstanding windows linked to particular fonts or CV windows (and we probably would), we'll have to set up an appropriate signal set. Things like "the window now shows a new character" and possibly even "a layer has been changed". Not a huge deal, though (probably). 

In theory this could also work with GXDraw by "promoting" spare X events to GDK events and passing them up the pipeline. But that seems a really unnecessary avenue for exploration, just asking for hours of investigation and debugging for a combination that doesn't add anything. 